### PR TITLE
Memorize todo

### DIFF
--- a/campscore/src/main/java/com/team5/campscore/controller/CampingController.java
+++ b/campscore/src/main/java/com/team5/campscore/controller/CampingController.java
@@ -219,8 +219,8 @@ public class CampingController {
 		if(params.get("region")!=null) {
 			region=params.get("region");
 		}
-		if(params.get("sort")!=null) {
-			switch(params.get("sort")) {
+		if(params.get("sort_type")!=null) {
+			switch(params.get("sort_type")) {
 				case "place_name": case "weather_score":
 					sortType = params.get("sort_type");
 			}
@@ -238,7 +238,7 @@ public class CampingController {
 		
 		
 		
-		int start = (page-1)*10 + 1;
+		int start = (page-1)*10;
 		
 		System.out.println("region="+region);
 		
@@ -252,6 +252,36 @@ public class CampingController {
 			
 			try {
 				BeanUtils.populate(campingMap, BeanUtils.describe(campingList.get(i)));
+				
+					String tmp=(String)campingMap.get("addressName");
+					if(tmp.indexOf("경기")==0) {
+						campingMap.put("region", "경기" );
+					}
+					if(tmp.indexOf("강원")==0) {
+						campingMap.put("region", "강원" );
+					}
+					if(tmp.indexOf("전북")==0) {
+						campingMap.put("region", "전북" );
+					}
+					if(tmp.indexOf("전남")==0) {
+						campingMap.put("region", "전남" );
+					}
+					if(tmp.indexOf("경북")==0) {
+						campingMap.put("region", "경북" );
+					}
+					if(tmp.indexOf("경남")==0) {
+						campingMap.put("region", "경남" );
+					}
+					if(tmp.indexOf("충북")==0) {
+						campingMap.put("region", "충북" );
+					}
+					if(tmp.indexOf("충남")==0) {
+						campingMap.put("region", "충남" );
+					}
+					if(tmp.indexOf("제주")==0) {
+						campingMap.put("region", "제주" );
+					}
+				
 			} catch (IllegalAccessException e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();
@@ -268,7 +298,6 @@ public class CampingController {
 			
 			campingMaps.put("item"+i,campingMap);
 		}
-		
 		return new ResponseEntity<>(campingMaps, HttpStatus.OK);
 	}
 	

--- a/campscore/src/main/java/com/team5/campscore/controller/SightController.java
+++ b/campscore/src/main/java/com/team5/campscore/controller/SightController.java
@@ -1,6 +1,7 @@
 package com.team5.campscore.controller;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -14,19 +15,22 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.team5.campscore.model.SightDTO;
+import com.team5.campscore.service.SightDAOImpl;
 
 
 @RestController
 public class SightController {
 	
-	//@Autowired
+	@Autowired
+	public SightDAOImpl sightService;
 	
 	@GetMapping(value ="get/sightlist")
-	ResponseEntity<Map<String, Map<String, Object>>> getCampingToViewByRegion(@RequestParam Map<String,String> params){
+	ResponseEntity<Map<String, Map<String, Object>>> getSightToView(@RequestParam Map<String,String> params){
 		int page; 
-		String region= "";
-		String sortType = "place_name"; 
+		String region= null;
+		String placeID = null;
 		String order = "asc";
+		
 		if(params.get("page")==null) {
 			page=1;
 		}else{
@@ -41,13 +45,7 @@ public class SightController {
 		if(params.get("region")!=null) {
 			region=params.get("region");
 		}
-		if(params.get("sort")!=null) {
-			switch(params.get("sort")) {
-				case "place_name": case "weather_score":
-					sortType = params.get("sort_type");
-			}
-			
-		}
+		
 		
 		if(params.get("order")!=null) {
 			switch(params.get("order")) {
@@ -56,34 +54,43 @@ public class SightController {
 			}
 			
 		}
+		/*
+		 * if (params.get("placeID") == null){ return null; }
+		 */
 		
 		
-		
-		
-		int start = (page-1)*10 + 1;
+		int start = (page-1)*8 ;
 		
 		System.out.println("region="+region);
 		
-		Map<String, Map<String, Object>> campingMaps= new HashMap<String, Map<String, Object>>();
-		List<SightDTO> SightList;
-		//campingList=campingService.getCampingListByRegion(start,region,sortType,order);
+		Map<String, Map<String, Object>> sightMaps= new HashMap<String, Map<String, Object>>();
+		List<SightDTO> sightList= new ArrayList<SightDTO>();
 		
-		/*
-		 * for(int i=0;i<campingList.size();i++) { Map<String, Object> campingMap = new
-		 * HashMap<String, Object>();
-		 * 
-		 * try { BeanUtils.populate(campingMap, BeanUtils.describe(campingList.get(i)));
-		 * } catch (IllegalAccessException e) { // TODO Auto-generated catch block
-		 * e.printStackTrace(); } catch (InvocationTargetException e) { // TODO
-		 * Auto-generated catch block e.printStackTrace(); } catch
-		 * (NoSuchMethodException e) { // TODO Auto-generated catch block
-		 * e.printStackTrace(); } System.out.println(campingMap.toString());
-		 * 
-		 * System.out.println(campingMap.get("placeID"));
-		 * 
-		 * campingMaps.put("item"+i,campingMap); }
-		 */
+		sightList=sightService.getSightList(region,start);
 		
-		return new ResponseEntity<>(campingMaps, HttpStatus.OK);
-	}
+		
+		  for(int i=0;i<sightList.size();i++) { 
+			  
+			  Map<String, Object> sightMap = new HashMap<String, Object>();
+		  
+			  try { 
+				  BeanUtils.populate(sightMap, BeanUtils.describe(sightList.get(i)));
+			  } 
+			  catch (IllegalAccessException e) {
+				  e.printStackTrace(); 
+			  } catch (InvocationTargetException e) { 
+				  e.printStackTrace();
+			  } catch (NoSuchMethodException e) { 
+				  e.printStackTrace(); 
+			  } 
+			  System.out.println(sightMap.toString());
+			  
+			  System.out.println(sightMap.get("placeID"));
+			  
+			  sightMaps.put("item"+i,sightMap); 
+		  }
+		 
+		
+		return new ResponseEntity<>(sightMaps, HttpStatus.OK);
+	}	
 }

--- a/campscore/src/main/java/com/team5/campscore/dao/SightDAO.java
+++ b/campscore/src/main/java/com/team5/campscore/dao/SightDAO.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,5 +27,6 @@ import com.team5.campscore.utilities.URLlib;
 
 @Mapper
 public interface SightDAO {
-	public int insertSight(SightDTO s);
+	public int insertSight(SightDTO sightDTO);
+	public List<SightDTO> getSightList(@Param("region")String region,@Param("start")int  start);
 }

--- a/campscore/src/main/java/com/team5/campscore/schedules/WeatherSchedule.java
+++ b/campscore/src/main/java/com/team5/campscore/schedules/WeatherSchedule.java
@@ -63,9 +63,6 @@ public class WeatherSchedule {
 				}
 	    	}
 		}
-    	
-    	
-		
 	}
 	
 	@Scheduled(cron = "0 0 0 * * *")

--- a/campscore/src/main/java/com/team5/campscore/service/SightDAOImpl.java
+++ b/campscore/src/main/java/com/team5/campscore/service/SightDAOImpl.java
@@ -1,5 +1,7 @@
 package com.team5.campscore.service;
 
+import java.util.List;
+
 import org.apache.ibatis.annotations.Mapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -8,14 +10,25 @@ import com.team5.campscore.dao.SightDAO;
 import com.team5.campscore.model.SightDTO;
 
 @Service
-public class SightDAOImpl {
+public class SightDAOImpl implements SightDAO {
 	@Autowired
 	private SightDAO dao;
 	
-	public int insertSight(SightDTO s){
+	public int insertSight(SightDTO sightDTO){
 		int returnVal =1;
-		returnVal=dao.insertSight(s);
+		dao.insertSight(sightDTO);
 		System.out.println(returnVal);
 		return returnVal;
 	};
+	public List<SightDTO> getSightList(String region, int start) {
+		List<SightDTO> sList=null;
+		try {
+			 sList=dao.getSightList(region,start);
+		}catch(Exception e){
+			e.printStackTrace();
+			return null;
+		}
+		
+		return sList;
+	}
 }

--- a/campscore/src/main/resources/sql/sight.xml
+++ b/campscore/src/main/resources/sql/sight.xml
@@ -8,6 +8,13 @@
 		insert into sight values(#{placeID},#{placeName},#{addressName},#{roadAddressName},#{placeUrl},#{placeImg},#{placeLat},#{placeLong},#{placeCategoryDetail})
 	</insert>
 	
+	<select id="getSightList" resultType="sight" >
+		SELECT place_id, place_name, COALESCE(road_address_name, address_name) AS address_name , place_url, place_img, place_long, place_lat, place_category_detail 
+		FROM sight
+		WHERE COALESCE(road_address_name, address_name) LIKE concat( #{region}, '%')  
+		order by place_name asc limit #{start},8;
+	</select>
+	
 	
 	
 


### PR DESCRIPTION
캠핑장 리스트 조회 메소드(get/campinglist)

요청

유효 요청 파라미터값: 

1. region: (String, option), valid values = [경기, 충북, 충남, 경북, 경남, 강원, 전북, 전남] 중 하나 or 공백(전역 지역)
2. category: (String, option), valid values = [카라반, 글램핑장, 오토캠핑장]중 하나 or 공백 (상세카테고리가 null인 캠핑장까지 전역 검색)
3. sort_type: (String, option) valid values = [place_name(캠핑장 이름 순),weather_score(날씨점수 순,추후 지원 예정)] or 공백(캠핑장이름 순으로 처리)
4. order: (String, option) valid values = [asc(오름차순),desc(내림차순)] or 공백(asc)

응답

객체 속에 item[0~9](맵 형식)이 있으며 각각의 아이템 내 필드(맴버변수)들은 camping 테이블을 구성하는 컬럼들의 캐멀 케이스 네임과  동일한 이름의 필드들+region(상단 유효 요청 파라미터 값 참조)으로 구성됨







관광지/문화시설 리스트 조회 메소드(get/sightlist)

요청

유효 요청 파라미터값: 

1. region (String, required), valid values = [경기, 충북, 충남, 경북, 경남, 강원, 전북, 전남] 중 하나

응답

객체속에 item[0~8](맵 형식)이 있으며 각각의 아이템 내 필드(맴버변수)들은 camping 테이블을 구성하는 컬럼들의 캐멀 케이스 네임과  동일한 이름의 필드들로 구성됨