### PR TITLE
캠핑장리스트 조회 기능에서 오름차순 내림차순이 올바르게 작동하지 않던 문제 해결

### DIFF
--- a/campscore/src/main/java/com/team5/campscore/controller/CampingController.java
+++ b/campscore/src/main/java/com/team5/campscore/controller/CampingController.java
@@ -136,8 +136,8 @@ public class CampingController {
 		if(params.get("region")!=null) {
 			region=params.get("region");
 		}
-		if(params.get("sort")!=null) {
-			switch(params.get("sort")) {
+		if(params.get("sort_type")!=null) {
+			switch(params.get("sort_type")) {
 				case "place_name": case "weather_score":
 					sortType = params.get("sort_type");
 			}
@@ -223,6 +223,7 @@ public class CampingController {
 			switch(params.get("sort_type")) {
 				case "place_name": case "weather_score":
 					sortType = params.get("sort_type");
+					
 			}
 		}
 		
@@ -240,7 +241,7 @@ public class CampingController {
 		
 		int start = (page-1)*10;
 		
-		System.out.println("region="+region);
+		System.out.println("region="+region+"sortType="+sortType);
 		
 		Map<String, Map<String, Object>> campingMaps= new HashMap<String, Map<String, Object>>();
 		List<CampingDTO> campingList;

--- a/campscore/src/main/resources/sql/camping.xml
+++ b/campscore/src/main/resources/sql/camping.xml
@@ -13,7 +13,7 @@
 		SELECT place_id, place_name,COALESCE(road_address_name, address_name) AS address_name ,place_url,place_img,place_long,place_lat,place_category_detail 
 		FROM camping
 		WHERE COALESCE(road_address_name, address_name) LIKE concat('%', #{region}, '%')  
-		order by #{sort_type} #{order} limit #{start},10;
+		order by #{sort_type} #{order} limit #{start},10
 	
 	</select>
 	
@@ -21,7 +21,8 @@
 		SELECT place_id, place_name,COALESCE(road_address_name, address_name) AS address_name ,place_url,place_img,place_long,place_lat,place_category_detail 
 		FROM camping
 		WHERE COALESCE(road_address_name, address_name) LIKE concat('%', #{region}, '%') and place_name LiKE concat('%', #{place_name}, '%') and place_category_detail LiKE concat('%', #{place_category_detail}, '%')
-		order by #{sort_type} #{order} limit #{start},10;
+		order by <if test="order=='asc'">place_name COLLATE utf8mb4_0900_ai_ci asc</if> <if test="order=='desc'">place_name COLLATE utf8mb4_0900_ai_ci desc</if> limit  #{start},10
+			
 	</select>
 
 </mapper>


### PR DESCRIPTION
캠핑장리스트 조회 기능에서 오름차순 내림차순이 올바르게 작동하지 않던 문제 해결 
정렬의  인코딩 기준을 조정하고 order by [컬럼명] 뒤에 플레이스 홀더를 사용해서 명령어(예약어)가 아닌 문자열 'asc' ,'desc'로 쿼리가 전달되어 생기던 문제를 해결했습니다